### PR TITLE
Moved Resolve-DNS inside try catch in check 108, 108_1 and 235

### DIFF
--- a/Checks/check-ORCA108.ps1
+++ b/Checks/check-ORCA108.ps1
@@ -40,9 +40,10 @@ class ORCA108 : ORCACheck
         ForEach($AcceptedDomain in $Config["AcceptedDomains"]) 
         {
             $HasMailbox = $false
-            $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX
+            
             try
             {
+                $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX -ErrorAction:stop
                 If($AcceptedDomain.Name -notlike "*.onmicrosoft.com") 
                { 
                    if($null -ne $mailbox -and $mailbox.Count -gt 0)

--- a/Checks/check-ORCA108.ps1
+++ b/Checks/check-ORCA108.ps1
@@ -43,9 +43,10 @@ class ORCA108 : ORCACheck
             
             try
             {
-                $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX -ErrorAction:stop
+                
                 If($AcceptedDomain.Name -notlike "*.onmicrosoft.com") 
                { 
+                   $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX -ErrorAction:Stop
                    if($null -ne $mailbox -and $mailbox.Count -gt 0)
                     {
                         $HasMailbox = $true

--- a/Checks/check-ORCA108_1.ps1
+++ b/Checks/check-ORCA108_1.ps1
@@ -41,9 +41,10 @@ class ORCA108_1 : ORCACheck
         ForEach($AcceptedDomain in $Config["AcceptedDomains"]) 
         {
             $HasMailbox = $false
-            $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX
+            
             try
             {
+                $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX
                 If($AcceptedDomain.Name -notlike "*.onmicrosoft.com") 
                { 
                    if($null -ne $mailbox -and $mailbox.Count -gt 0)

--- a/Checks/check-ORCA108_1.ps1
+++ b/Checks/check-ORCA108_1.ps1
@@ -44,7 +44,7 @@ class ORCA108_1 : ORCACheck
             
             try
             {
-                $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX
+                $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX -ErrorAction:Stop
                 If($AcceptedDomain.Name -notlike "*.onmicrosoft.com") 
                { 
                    if($null -ne $mailbox -and $mailbox.Count -gt 0)

--- a/Checks/check-ORCA108_1.ps1
+++ b/Checks/check-ORCA108_1.ps1
@@ -44,10 +44,11 @@ class ORCA108_1 : ORCACheck
             
             try
             {
-                $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX -ErrorAction:Stop
+                
                 If($AcceptedDomain.Name -notlike "*.onmicrosoft.com") 
                { 
-                   if($null -ne $mailbox -and $mailbox.Count -gt 0)
+                    $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX -ErrorAction:Stop
+                    if($null -ne $mailbox -and $mailbox.Count -gt 0)
                     {
                         $HasMailbox = $true
                     }

--- a/Checks/check-ORCA235.ps1
+++ b/Checks/check-ORCA235.ps1
@@ -42,10 +42,10 @@ class ORCA235 : ORCACheck
                 'ErrorAction' = 'SilentlyContinue'
             }
             $HasMailbox = $false
-            $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name)-Type MX
 
             try
             {
+                $mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name)-Type MX -ErrorAction:Stop
                 if($null -ne $mailbox -and $mailbox.Count -gt 0)
                 {
                     $HasMailbox = $true


### PR DESCRIPTION
Fixing issue where a domain still present in the tenant, does not exist as a domain anymore.
Moving the "$mailbox = Resolve-DnsName -Name $($AcceptedDomain.Name) -Type MX -ErrorAction:Stop" at the start of check-ORCA108.ps1, check-ORCA108_1.ps1 and check-ORCA235.ps1 inside the try-catch block and adding the -ErrorAction:Stop made the report continue. 