### PR TITLE
Revert "deprecate 226 and 227 #187"

### DIFF
--- a/Checks/check-ORCA226.ps1
+++ b/Checks/check-ORCA226.ps1
@@ -1,0 +1,169 @@
+<#
+
+226 - Check Safe Links Policy Exists for all domains
+
+#>
+
+using module "..\ORCA.psm1"
+
+class ORCA226 : ORCACheck
+{
+    <#
+    
+        CONSTRUCTOR with Check Header Data
+    
+    #>
+
+    ORCA226()
+    {
+        $this.Control=226
+        $this.Services=[ORCAService]::OATP
+        $this.Area="Advanced Threat Protection Policies"
+        $this.Name="Safe Links Policy Rules"
+        $this.PassText="Each domain has a Safe Link policy applied to it"
+        $this.FailRecommendation="Apply a Safe Links policy to every domain"
+        $this.Importance="Office 365 ATP Safe Links policies are applied using rules. The recipient domain condition is the most effective way of applying the Safe Links policy, ensuring no users are left without protection. If polices are applied using group membership make sure you cover all users through this method. Applying polices this way can be challenging, users may left unprotected if group memberships are not accurate and up to date."
+        $this.ExpandResults=$True
+        $this.CheckType=[CheckType]::ObjectPropertyValue
+        $this.ObjectType="Domain"
+        $this.ItemName="Policy"
+        $this.DataType="Priority"
+        $this.ChiValue=[ORCACHI]::High
+        $this.Links= @{
+            "Security & Compliance Center - Safe links"="https://aka.ms/orca-atpp-action-safelinksv2"
+            "Order and precedence of email protection"="https://aka.ms/orca-atpp-docs-4"
+            "Recommended settings for EOP and Office 365 ATP security"="https://aka.ms/orca-atpp-docs-7"
+        }
+    }
+
+    <#
+    
+        RESULTS
+    
+    #>
+
+    GetResults($Config)
+    {
+
+        ForEach($AcceptedDomain in $Config["AcceptedDomains"]) 
+        {
+
+            # Set up the config object
+
+            $Rules = @()
+
+            # Go through each Safe Links Policy
+
+            ForEach($Rule in ($Config["SafeLinksRules"] | Sort-Object Priority)) 
+            {
+                if($Rule.State -eq "Enabled")
+                {
+                    if($Rule.RecipientDomainIs -contains $AcceptedDomain.Name -and ($Rule.ExceptIfRecipientDomainIs -notcontains $AcceptedDomain.Name) -and ($null -eq $Rule.ExceptIfSentToMemberOf ) -and ($null -eq $Rule.ExceptIfSentTo) )
+                    {
+                        # Policy applies to this domain
+
+                        $Rules += New-Object -TypeName PSObject -Property @{
+                            PolicyName=$($Rule.SafeLinksPolicy)
+                            Priority=$($Rule.Priority)
+                        }
+
+                    }
+                }
+            }
+            ForEach($Rule in ($Config["ATPProtectionPolicyRule"] | Sort-Object Priority)) 
+            {
+                if(($Rule.SafeLinksPolicy -ne "") -and ($null -ne $Rule.SafeLinksPolicy ))
+                { 
+                   if($Rule.State -eq "Enabled")
+                   {
+                        if($Rule.RecipientDomainIs -contains $AcceptedDomain.Name -and ($Rule.ExceptIfRecipientDomainIs -notcontains $AcceptedDomain.Name) -and ($null -eq $Rule.ExceptIfSentToMemberOf ) -and ($null -eq $Rule.ExceptIfSentTo) )
+                        {
+                            # Policy applies to this domain
+
+                            $Rules += New-Object -TypeName PSObject -Property @{
+                            PolicyName=$($Rule.SafeLinksPolicy)
+                            Priority=$($Rule.Priority)
+                            }
+
+                        }   
+                    }
+                }
+            }
+            If($Rules.Count -gt 0)
+            {
+                $Count = 0
+                $CountOfPolicies = ($Rules).Count
+
+                ForEach($r in ($Rules | Sort-Object Priority))
+                {
+                    $IsBuiltIn = $false
+                    $policyname = $($r.PolicyName)
+                    $priority =$($r.Priority)
+                    if($policyname -match "Built-In" -and $CountOfPolicies -gt 1)
+                    {
+                        $IsBuiltIn =$True
+                        $policyname = "$policyname" +" [Built-In]"
+                    }
+                    elseif(($policyname -eq "Default" -or $policyname -eq "Office365 AntiPhish Default") -and $CountOfPolicies -gt 1)
+                    {
+                        $IsBuiltIn =$True
+                        $policyname = "$policyname" +" [Default]"
+                    }
+
+                    $Count++
+
+                    $ConfigObject = [ORCACheckConfig]::new()
+
+                    $ConfigObject.Object=$($AcceptedDomain.Name)
+                    $ConfigObject.ConfigItem=$policyname
+                    $ConfigObject.ConfigData=$priority
+
+                    If($Count -eq 1)
+                    {
+                        # First policy based on priority is a pass
+                        if($IsBuiltIn)
+                        {
+                            $ConfigObject.InfoText = "This is a Built-In/Default policy managed by Microsoft and therefore cannot be edited. Other policies are set up in this area. It is being flagged only for informational purpose."
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Informational,"Fail")
+                        }
+                        else
+                        {
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Standard,"Pass")
+                        }
+                    }
+                    else
+                    {
+                        if($IsBuiltIn)
+                        {
+                            $ConfigObject.InfoText = "This is a Built-In/Default policy managed by Microsoft and therefore cannot be edited. Other policies are set up in this area. It is being flagged only for informational purpose."
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Informational,"Fail")
+                        }
+                        else
+                        {
+                        # Additional policies based on the priority should be listed as informational
+                            $ConfigObject.InfoText = "There are multiple policies that apply to this domain, only the policy with the lowest priority will apply. This policy may not apply based on a lower priority."
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Informational,"Fail")
+                        }
+                    }    
+
+                    $this.AddConfig($ConfigObject)
+                }
+            } 
+            elseif($Rules.Count -eq 0)
+            {
+                # No policy is applying to this domain
+
+                $ConfigObject = [ORCACheckConfig]::new()
+
+                $ConfigObject.Object=$($AcceptedDomain.Name)
+                $ConfigObject.ConfigItem="No Policy Applying"
+                $ConfigObject.SetResult([ORCAConfigLevel]::Standard,"Fail")            
+    
+                $this.AddConfig($ConfigObject)     
+            }
+
+        }
+
+    }
+
+}

--- a/Checks/check-ORCA227.ps1
+++ b/Checks/check-ORCA227.ps1
@@ -1,0 +1,170 @@
+<#
+
+227 - Check Safe Attachments Policy Exists for all domains
+
+#>
+
+using module "..\ORCA.psm1"
+
+class ORCA227 : ORCACheck
+{
+    <#
+    
+        CONSTRUCTOR with Check Header Data
+    
+    #>
+
+    ORCA227()
+    {
+        $this.Control=227
+        $this.Services=[ORCAService]::OATP
+        $this.Area="Advanced Threat Protection Policies"
+        $this.Name="Safe Attachments Policy Rules"
+        $this.PassText="Each domain has a Safe Attachments policy applied to it"
+        $this.FailRecommendation="Apply a Safe Attachments policy to every domain"
+        $this.Importance="Office 365 ATP Safe Attachments policies are applied using rules. The recipient domain condition is the most effective way of applying the Safe Attachments policy, ensuring no users are left without protection. If polices are applied using group membership make sure you cover all users through this method. Applying polices this way can be challenging, users may left unprotected if group memberships are not accurate and up to date."
+        $this.ExpandResults=$True
+        $this.CheckType=[CheckType]::ObjectPropertyValue
+        $this.ObjectType="Domain"
+        $this.ItemName="Policy"
+        $this.DataType="Priority"
+        $this.ChiValue=[ORCACHI]::High
+        $this.Links= @{
+            "Security & Compliance Center - Safe attachments"="https://aka.ms/orca-atpp-action-safeattachment"
+            "Order and precedence of email protection"="https://aka.ms/orca-atpp-docs-4"
+            "Recommended settings for EOP and Office 365 ATP security"="https://aka.ms/orca-atpp-docs-7"
+        }
+    }
+
+    <#
+    
+        RESULTS
+    
+    #>
+
+    GetResults($Config)
+    {
+
+        ForEach($AcceptedDomain in $Config["AcceptedDomains"]) 
+        {
+
+            # Set up the config object
+
+            $Rules = @()
+
+            # Go through each Safe Links Policy
+
+            ForEach($Rule in ($Config["SafeAttachmentsRules"] | Sort-Object Priority)) 
+            {
+                if($Rule.State -eq "Enabled")
+                {
+                    if($Rule.RecipientDomainIs -contains $AcceptedDomain.Name -and ($Rule.ExceptIfRecipientDomainIs -notcontains $AcceptedDomain.Name) -and ($null -eq $Rule.ExceptIfSentToMemberOf ) -and ($null -eq $Rule.ExceptIfSentTo) )
+                    {
+                        # Policy applies to this domain
+
+                        $Rules += New-Object -TypeName PSObject -Property @{
+                            PolicyName=$($Rule.SafeAttachmentPolicy)
+                            Priority=$($Rule.Priority)
+                        }
+
+                    }
+                }
+
+            }
+            ForEach($Rule in ($Config["ATPProtectionPolicyRule"] | Sort-Object Priority)) 
+            {
+                if(($Rule.SafeAttachmentPolicy -ne "") -and ($null -ne $Rule.SafeAttachmentPolicy ))
+                { 
+                   if($Rule.State -eq "Enabled")
+                   {
+                    if($Rule.RecipientDomainIs -contains $AcceptedDomain.Name -and ($Rule.ExceptIfRecipientDomainIs -notcontains $AcceptedDomain.Name) -and ($null -eq $Rule.ExceptIfSentToMemberOf ) -and ($null -eq $Rule.ExceptIfSentTo) )
+                        {
+                            # Policy applies to this domain
+
+                            $Rules += New-Object -TypeName PSObject -Property @{
+                            PolicyName=$($Rule.SafeAttachmentPolicy)
+                            Priority=$($Rule.Priority)
+                            }
+
+                        }   
+                    }
+                }
+            }
+
+            If($Rules.Count -gt 0)
+            {
+                $Count = 0
+                $CountOfPolicies = ($Rules).Count
+                ForEach($r in ($Rules | Sort-Object Priority))
+                {
+                    $IsBuiltIn = $false
+                    $policyname = $($r.PolicyName)
+                    $priority =$($r.Priority)
+                    if($policyname -match "Built-In" -and $CountOfPolicies -gt 1)
+                    {
+                        $IsBuiltIn =$True
+                        $policyname = "$policyname" +" [Built-In]"
+                    }
+                    elseif(($policyname -eq "Default" -or $policyname -eq "Office365 AntiPhish Default") -and $CountOfPolicies -gt 1)
+                    {
+                        $IsBuiltIn =$True
+                        $policyname = "$policyname" +" [Default]"
+                    }
+
+                    $Count++
+
+                    $ConfigObject = [ORCACheckConfig]::new()
+
+                    $ConfigObject.Object=$($AcceptedDomain.Name)
+                    $ConfigObject.ConfigItem=$policyname
+                    $ConfigObject.ConfigData=$priority
+
+                    If($Count -eq 1)
+                    {
+                        # First policy based on priority is a pass
+                        if($IsBuiltIn)
+                        {
+                            $ConfigObject.InfoText = "This is a Built-In/Default policy managed by Microsoft and therefore cannot be edited. Other policies are set up in this area. It is being flagged only for informational purpose."
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Informational,"Fail")
+                        }
+                        else
+                        {
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Standard,"Pass")
+                        }
+                    }
+                    else
+                    {
+                        if($IsBuiltIn)
+                        {
+                            $ConfigObject.InfoText = "This is a Built-In/Default policy managed by Microsoft and therefore cannot be edited. Other policies are set up in this area. It is being flagged only for informational purpose."
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Informational,"Fail")
+                        }
+                        else
+                        {
+                        # Additional policies based on the priority should be listed as informational
+                            $ConfigObject.InfoText = "There are multiple policies that apply to this domain, only the policy with the lowest priority will apply. This policy may not apply based on a lower priority."
+                            $ConfigObject.SetResult([ORCAConfigLevel]::Informational,"Fail")
+                        }
+                    } 
+
+                    $this.AddConfig($ConfigObject)
+                }
+            } 
+            elseif($Rules.Count -eq 0)
+            {
+                # No policy is applying to this domain
+
+                $ConfigObject = [ORCACheckConfig]::new()
+
+                $ConfigObject.Object=$($AcceptedDomain.Name)
+                $ConfigObject.ConfigItem="No Policy Applying"
+                $ConfigObject.SetResult([ORCAConfigLevel]::Standard,"Fail")            
+    
+                $this.AddConfig($ConfigObject)     
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Reverts cammurray/orca#195

226 and 227 are still required as the built-in policy only provided minimum protection.